### PR TITLE
Add Maven-based Android Bluetooth HID app and CI workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,34 @@
+name: Android Maven Build
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+          cache: 'maven'
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v3
+        with:
+          api-level: 33
+          build-tools: 33.0.2
+      - name: Delete previous artifacts
+        uses: geekyeggo/delete-artifact@v2
+        with:
+          name: androhid-apk
+        continue-on-error: true
+      - name: Build APK
+        run: mvn -B clean package
+      - name: Upload APK
+        uses: actions/upload-artifact@v3
+        with:
+          name: androhid-apk
+          path: target/*.apk

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/target/
+.idea/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
-# androhid
+# AndroHID
+
+Пример Android-приложения на Java, выступающего в роли HID-устройства по Bluetooth.
+
+## Сборка
+
+Проект использует Maven и плагин `android-maven-plugin`. Для сборки APK:
+
+```bash
+mvn clean package
+```
+
+## Тестирование
+
+Интеграционные тесты реализованы с использованием Robolectric и запускаются командой:
+
+```bash
+mvn test
+```
+
+## CI
+
+В репозитории настроен workflow GitHub Actions, который собирает APK и очищает предыдущие артефакты.

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,65 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.example</groupId>
+    <artifactId>androhid</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>apk</packaging>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <android.sdk.path>${env.ANDROID_HOME}</android.sdk.path>
+        <android.sdk.platform>33</android.sdk.platform>
+    </properties>
+
+    <repositories>
+        <repository>
+            <id>central</id>
+            <url>https://repo1.maven.org/maven2</url>
+        </repository>
+        <repository>
+            <id>google</id>
+            <url>https://maven.google.com</url>
+        </repository>
+    </repositories>
+
+    <dependencies>
+        <dependency>
+            <groupId>androidx.appcompat</groupId>
+            <artifactId>appcompat</artifactId>
+            <version>1.6.1</version>
+        </dependency>
+        <dependency>
+            <groupId>androidx.test</groupId>
+            <artifactId>core</artifactId>
+            <version>1.5.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.robolectric</groupId>
+            <artifactId>robolectric</artifactId>
+            <version>4.9.2</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.simpligility.maven.plugins</groupId>
+                <artifactId>android-maven-plugin</artifactId>
+                <version>4.4.1</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <sdk>
+                        <platform>${android.sdk.platform}</platform>
+                        <path>${android.sdk.path}</path>
+                    </sdk>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/androidTest/java/com/example/androhid/HidServiceTest.java
+++ b/src/androidTest/java/com/example/androhid/HidServiceTest.java
@@ -1,0 +1,27 @@
+package com.example.androhid;
+
+import android.bluetooth.BluetoothAdapter;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import static org.junit.Assert.*;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = 28)
+public class HidServiceTest {
+    @Test
+    public void bluetoothAdapterAvailable() {
+        BluetoothAdapter adapter = BluetoothAdapter.getDefaultAdapter();
+        assertNotNull(adapter);
+    }
+
+    @Test
+    public void serviceCanBeCreated() {
+        HidService service = Robolectric.buildService(HidService.class).create().get();
+        assertNotNull(service);
+    }
+}

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -1,0 +1,26 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.androhid">
+
+    <uses-permission android:name="android.permission.BLUETOOTH" />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+    <uses-feature android:name="android.hardware.bluetooth" />
+
+    <application
+        android:label="@string/app_name"
+        android:allowBackup="true"
+        android:supportsRtl="true">
+        <activity android:name=".MainActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+        <service android:name=".HidService"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.bluetooth.BluetoothHidDevice" />
+            </intent-filter>
+        </service>
+    </application>
+</manifest>

--- a/src/main/java/com/example/androhid/HidService.java
+++ b/src/main/java/com/example/androhid/HidService.java
@@ -1,0 +1,78 @@
+package com.example.androhid;
+
+import android.app.Service;
+import android.bluetooth.BluetoothAdapter;
+import android.bluetooth.BluetoothDevice;
+import android.bluetooth.BluetoothHidDevice;
+import android.bluetooth.BluetoothHidDeviceAppQosSettings;
+import android.bluetooth.BluetoothHidDeviceAppSdpSettings;
+import android.bluetooth.BluetoothProfile;
+import android.content.Intent;
+import android.os.IBinder;
+import android.util.Log;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+public class HidService extends Service implements BluetoothProfile.ServiceListener {
+    private static final String TAG = "HidService";
+    private BluetoothHidDevice hidDevice;
+    private BluetoothAdapter adapter;
+    private final ExecutorService executor = Executors.newSingleThreadExecutor();
+
+    private final BluetoothHidDevice.Callback callback = new BluetoothHidDevice.Callback() {
+        @Override
+        public void onAppStatusChanged(BluetoothDevice pluggedDevice, boolean registered) {
+            Log.d(TAG, "App status changed: " + registered);
+        }
+    };
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        adapter = BluetoothAdapter.getDefaultAdapter();
+        if (adapter != null) {
+            adapter.getProfileProxy(this, this, BluetoothProfile.HID_DEVICE);
+        }
+    }
+
+    @Override
+    public int onStartCommand(Intent intent, int flags, int startId) {
+        return START_STICKY;
+    }
+
+    @Override
+    public IBinder onBind(Intent intent) {
+        return null;
+    }
+
+    @Override
+    public void onDestroy() {
+        if (adapter != null && hidDevice != null) {
+            hidDevice.unregisterApp();
+            adapter.closeProfileProxy(BluetoothProfile.HID_DEVICE, hidDevice);
+        }
+        executor.shutdown();
+        super.onDestroy();
+    }
+
+    @Override
+    public void onServiceConnected(int profile, BluetoothProfile proxy) {
+        if (profile == BluetoothProfile.HID_DEVICE) {
+            hidDevice = (BluetoothHidDevice) proxy;
+            BluetoothHidDeviceAppSdpSettings sdp = new BluetoothHidDeviceAppSdpSettings(
+                    "HID Keyboard", "Keyboard", "Android",
+                    BluetoothHidDevice.SUBCLASS1_COMBO, null);
+            BluetoothHidDeviceAppQosSettings inQos = new BluetoothHidDeviceAppQosSettings(
+                    BluetoothHidDeviceAppQosSettings.SERVICE_BEST_EFFORT, 800, 9, 0, 11250, 11250);
+            hidDevice.registerApp(sdp, null, inQos, executor, callback);
+        }
+    }
+
+    @Override
+    public void onServiceDisconnected(int profile) {
+        if (profile == BluetoothProfile.HID_DEVICE) {
+            hidDevice = null;
+        }
+    }
+}

--- a/src/main/java/com/example/androhid/MainActivity.java
+++ b/src/main/java/com/example/androhid/MainActivity.java
@@ -1,0 +1,13 @@
+package com.example.androhid;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.os.Bundle;
+
+public class MainActivity extends Activity {
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        startService(new Intent(this, HidService.class));
+    }
+}

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">AndroHID</string>
+</resources>


### PR DESCRIPTION
## Summary
- Add Bluetooth HID example app in Java using Maven
- Implement Robolectric integration tests
- Configure GitHub Actions to build APK and remove previous artifacts

## Testing
- `mvn -q -ntp test` *(fails: Unresolveable build extension: android-maven-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_689b833080a4832a83e290ecb5d63940